### PR TITLE
Refactor TrainingSeriesView, add nested routes, boilerplate posts Redux

### DIFF
--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -50,7 +50,7 @@ class Dashboard extends React.Component {
               </h4>
               <div>
                 <div style={this.state.tabValue === 0 ? active : hidden}>
-                  <TrainingSeriesView userId={this.state.user.user.userID} />
+                  <TrainingSeriesView userId={this.state.user.user.userID} match={this.props.match} />
                 </div>
                 <div style={this.state.tabValue === 1 ? active : hidden}>
                   <TeamMembersView userId={this.state.user.user.userID} />

--- a/client/src/components/Modals/PostModal.js
+++ b/client/src/components/Modals/PostModal.js
@@ -1,0 +1,104 @@
+// displays individual post modal
+import React from "react";
+
+//Prop Types
+import PropTypes from "prop-types";
+
+// Styles
+import { withStyles } from "@material-ui/core/styles";
+import Modal from "@material-ui/core/Modal";
+import Button from "@material-ui/core/Button";
+
+// Redux
+import { connect } from "react-redux";
+import { createAPost } from "../../store/actions";
+
+function getModalStyle() {
+  const top = 50;
+  const left = 50;
+
+  return {
+    top: `${top}%`,
+    left: `${left}%`,
+    transform: `translate(-${top}%, -${left}%)`
+  };
+}
+
+const styles = theme => ({
+  paper: {
+    position: "absolute",
+    width: theme.spacing.unit * 25,
+    backgroundColor: theme.palette.background.paper,
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing.unit * 4,
+    outline: "none"
+  },
+  container: {
+    display: "flex",
+    flexWrap: "wrap"
+  },
+  textField: {
+    marginLeft: theme.spacing.unit,
+    marginRight: theme.spacing.unit,
+    width: 200
+  },
+  dense: {
+    marginTop: 19
+  },
+  menu: {
+    width: 200
+  },
+  button: {
+    margin: theme.spacing.unit
+  }
+});
+
+class PostModal extends React.Component {
+  state = {
+    open: false
+  };
+
+  handleOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
+  createAPost = e => {
+    e.preventDefault();
+    // logic here
+  };
+
+  render() {
+    const { classes } = this.props;
+    return (
+      <>
+        <Button onClick={this.handleOpen}>Create a new post</Button>
+        <Modal
+          aria-labelledby="simple-modal-title"
+          aria-describedby="simple-modal-description"
+          open={this.state.open}
+          onClose={this.handleClose}
+        >
+          <div style={getModalStyle()} className={classes.paper}>
+            <p>Post Modal!</p>
+            <Button onClick={this.handleCloser}>Cancel</Button>
+          </div>
+        </Modal>
+      </>
+    );
+  }
+}
+
+PostModal.propTypes = {};
+
+const mapStateToProps = state => ({});
+
+const PostModalWrapped = withStyles(styles)(PostModal);
+
+export default connect(
+  null,
+  {}
+)(PostModalWrapped);

--- a/client/src/components/TrainingSeries/Post.js
+++ b/client/src/components/TrainingSeries/Post.js
@@ -1,1 +1,0 @@
-// displays individual post modal

--- a/client/src/components/TrainingSeries/TrainingSeries.js
+++ b/client/src/components/TrainingSeries/TrainingSeries.js
@@ -1,5 +1,6 @@
 // displays training series card
 import React from "react";
+import { Link } from 'react-router-dom';
 
 //PropTypes
 import PropTypes from "prop-types";
@@ -40,7 +41,8 @@ function SeriesCard(props) {
         <Typography>test data</Typography>
       </CardContent>
       <CardActions>
-        <Button size='small'>Edit</Button>
+        <Link to={`${props.match.url}/training-series/${props.data.trainingSeriesID}`}><Button size='small'>View Posts</Button></Link>
+        <Button size="small">Edit</Button>
         <Button
           onClick={() =>
             props.deleteTrainingSeries(props.data.trainingSeriesID)

--- a/client/src/components/TrainingSeries/TrainingSeries.js
+++ b/client/src/components/TrainingSeries/TrainingSeries.js
@@ -1,4 +1,4 @@
-// displays individual training series' posts
+// displays training series card
 import React from "react";
 
 //PropTypes

--- a/client/src/components/TrainingSeries/TrainingSeriesList.js
+++ b/client/src/components/TrainingSeries/TrainingSeriesList.js
@@ -19,6 +19,7 @@ const TrainingSeriesList = props => {
               key={series.trainingSeriesID}
               deleteTrainingSeries={props.deleteTrainingSeries}
               data={series}
+              match={props.match}
             />
           );
         })}

--- a/client/src/components/TrainingSeries/TrainingSeriesPosts.js
+++ b/client/src/components/TrainingSeries/TrainingSeriesPosts.js
@@ -1,0 +1,25 @@
+// displays all posts of a training series
+import React from "react";
+
+// Components
+import PostModal from '../Modals/PostModal';
+
+//PropTypes
+import PropTypes from "prop-types";
+
+// Styling
+import Button from "@material-ui/core/Button";
+
+function TrainingSeriesPosts(props) {
+    return (
+        <>
+        <PostModal />
+        </>
+    )
+}
+
+TrainingSeriesPosts.propTypes = {
+
+}
+
+export default TrainingSeriesPosts;

--- a/client/src/components/TrainingSeries/TrainingSeriesPosts.js
+++ b/client/src/components/TrainingSeries/TrainingSeriesPosts.js
@@ -11,9 +11,14 @@ import PropTypes from "prop-types";
 import Button from "@material-ui/core/Button";
 
 function TrainingSeriesPosts(props) {
+    console.log("props in TSP", props);
+    const series = props.trainingSeries.find(series => `${series.trainingSeriesID}` === props.match.params.id);
+    console.log("series", series);
     return (
         <>
         <PostModal />
+        {series.trainingSeriesID}
+        {series.title}
         </>
     )
 }

--- a/client/src/components/TrainingSeries/TrainingSeriesSubView.js
+++ b/client/src/components/TrainingSeries/TrainingSeriesSubView.js
@@ -1,0 +1,26 @@
+import React, { Component } from "react";
+
+//Components
+import TrainingSeriesList from "./TrainingSeriesList";
+import TrainingSeriesModal from "../Modals/TrainingSeriesModal";
+
+class TrainingSeriesSubView extends Component {
+    render() {
+        return (
+            <>
+                  <TrainingSeriesModal
+                getTrainingSeries={this.props.getTrainingSeries}
+                userID={this.props.userID}
+              />
+              <TrainingSeriesList
+                deleteTrainingSeries={this.props.deleteTrainingSeries}
+                trainingSeries={this.props.trainingSeries}
+                match={this.props.match}
+              />
+            </>
+        )
+    }
+
+}
+
+export default TrainingSeriesSubView;

--- a/client/src/components/TrainingSeries/TrainingSeriesView.js
+++ b/client/src/components/TrainingSeries/TrainingSeriesView.js
@@ -1,13 +1,14 @@
 // component to contain all the components related to training series
 import React, { Component } from "react";
+import { Route } from "react-router-dom";
 
 //REDUX
 import { connect } from "react-redux";
 import { getTrainingSeries, deleteTrainingSeries } from "../../store/actions/";
 
 //Components
-import TrainingSeriesList from "./TrainingSeriesList";
-import TrainingSeriesModal from "../Modals/TrainingSeriesModal";
+import TrainingSeriesSubView from "./TrainingSeriesSubView";
+import TrainingSeriesPosts from "./TrainingSeriesPosts";
 
 class TrainingSeriesView extends Component {
   componentDidMount() {
@@ -29,17 +30,30 @@ class TrainingSeriesView extends Component {
   };
 
   render() {
-    console.log(this.props.trainingSeries);
     return (
       <div>
         <>
-          <TrainingSeriesModal
-            getTrainingSeries={this.props.getTrainingSeries}
-            userID={this.props.userId}
+          <Route
+            exact
+            path={`${this.props.match.path}`}
+            render={props => (
+              <TrainingSeriesSubView
+                {...props}
+                trainingSeries={this.props.trainingSeries}
+                deleteTrainingSeries={this.deleteTrainingSeries}
+                getTrainingSeries={this.props.getTrainingSeries}
+                userID={this.props.userId}
+              />
+            )}
           />
-          <TrainingSeriesList
-            deleteTrainingSeries={this.deleteTrainingSeries}
-            trainingSeries={this.props.trainingSeries}
+          <Route
+            path={`${this.props.match.path}/training-series/:id`}
+            render={props => (
+              <TrainingSeriesPosts
+                {...props}
+                trainingSeries={this.props.trainingSeries}
+              />
+            )}
           />
         </>
       </div>

--- a/client/src/store/actions/index.js
+++ b/client/src/store/actions/index.js
@@ -1,3 +1,5 @@
 export {} from "./teamMembersActions";
 
 export * from "./trainingSeriesActions";
+
+export * from './postsActions';

--- a/client/src/store/actions/postsActions.js
+++ b/client/src/store/actions/postsActions.js
@@ -1,0 +1,68 @@
+import axios from "axios";
+
+// GET POSTS
+export const GET_POSTS_START = "GET_POSTS_START";
+export const GET_POSTS_SUCCESS = "GET_POSTS_SUCCESS";
+export const GET_POSTS_FAIL = "GET_POSTS_FAIL";
+
+// GET SINGLE POST
+export const GET_SINGLE_POST_START = "GET_SINGLE_POST_START";
+export const GET_SINGLE_POST_SUCCESS = "GET_SINGLE_POST_SUCCESS";
+export const GET_SINGLE_POST_FAIL = "GET_SINGLE_POST_FAIL";
+
+// ADD A NEW POST
+export const ADD_POST_START = "ADD_POST_START";
+export const ADD_POST_SUCCESS = "ADD_POST_SUCCESS";
+export const ADD_POST_FAIL = "ADD_POST_FAIL";
+
+// EDIT A POST
+// export const EDIT_POST_START = "EDIT_POST_START";
+// export const EDIT_POST_SUCCESS = "EDIT_POST_SUCCESS";
+// export const EDIT_POST_FAIL = "EDIT_POST_FAIL";
+
+// // DELETE A POST
+// export const DELETE_POST_START = "DELETE_POST_START";
+// export const DELETE_POST_SUCCESS = "DELETE_POST_SUCCESS";
+// export const DELETE_POST_FAIL = "DELETE_POST_FAIL";
+
+// GET all posts for a training series
+export const getTrainingSeriesPosts = id => dispatch => {
+  dispatch({
+    type: GET_POSTS_START
+  });
+  axios
+    .get(`${process.env.REACT_APP_API}/api/training-series/${id}/posts`)
+    .then(res =>
+      dispatch({
+        type: GET_POSTS_SUCCESS,
+        payload: res.data.posts
+      })
+    )
+    .catch(err => dispatch({ type: GET_POSTS_FAIL, error: err }));
+};
+
+//GET a single post by id
+export const getPostById = id => dispatch => {
+  dispatch({ type: GET_SINGLE_POST_START });
+  axios
+    .get(`${process.env.REACT_APP_API}/api/posts/${id}`)
+    .then(res =>
+      dispatch({ type: GET_SINGLE_POST_SUCCESS, payload: res.data.post })
+    )
+    .catch(err => dispatch({ type: GET_SINGLE_POST_FAIL, error: err }));
+};
+
+// POST a new post
+export const createAPost = post => dispatch => {
+  dispatch({ type: ADD_POST_START });
+  axios
+    .post(`${process.env.REACT_APP_API}/api/posts`, post)
+    .then(res =>
+      dispatch({ type: ADD_POST_SUCCESS, payload: res.data.newPost })
+    )
+    .catch(err => dispatch({ type: ADD_POST_FAIL, error: err }));
+};
+
+// PUT a post
+
+// DELETE a post

--- a/client/src/store/reducers/index.js
+++ b/client/src/store/reducers/index.js
@@ -1,11 +1,11 @@
-import teamMemberReducer from "./teamMembersReducer";
+import teamMembersReducer from "./teamMembersReducer";
 import trainingSeriesReducer from "./trainingSeriesReducer";
 import postsReducer from './postsReducer';
 
 import { combineReducers } from "redux";
 
 const rootReducer = combineReducers({
-  teamMemberReducer,
+  teamMembersReducer,
   trainingSeriesReducer,
   postsReducer
 });

--- a/client/src/store/reducers/index.js
+++ b/client/src/store/reducers/index.js
@@ -1,11 +1,13 @@
 import teamMemberReducer from "./teamMembersReducer";
 import trainingSeriesReducer from "./trainingSeriesReducer";
+import postsReducer from './postsReducer';
 
 import { combineReducers } from "redux";
 
 const rootReducer = combineReducers({
   teamMemberReducer,
-  trainingSeriesReducer
+  trainingSeriesReducer,
+  postsReducer
 });
 
 export default rootReducer;

--- a/client/src/store/reducers/postsReducer.js
+++ b/client/src/store/reducers/postsReducer.js
@@ -1,0 +1,85 @@
+import {
+    GET_POSTS_START,
+    GET_POSTS_SUCCESS,
+    GET_POSTS_FAIL,
+    GET_SINGLE_POST_START,
+    GET_SINGLE_POST_SUCCESS,
+    GET_SINGLE_POST_FAIL,
+    ADD_POST_START,
+    ADD_POST_SUCCESS,
+    ADD_POST_FAIL
+} from '../actions';
+
+const initialState = {
+    posts: [],
+    singlePost: [],
+    isLoading: false,
+    error: "",
+    addedSuccessfully: false
+}
+
+const postsReducer = (state = initialState, action) => {
+    switch (action.type) {
+        // ---GET ACTIVITIES---
+        case GET_POSTS_START:
+        return {
+            ...state,
+            isLoading: true,
+            error: ""
+        };
+        case GET_POSTS_SUCCESS:
+        return {
+            ...state,
+            isLoading: false,
+            posts: action.payload
+
+        };
+        case GET_POSTS_FAIL:
+        return {
+            ...state,
+            isLoading: false,
+            error: action.payload
+        };
+        case GET_SINGLE_POST_START:
+        return {
+            ...state,
+            isLoading: true,
+            error: ""
+        };
+        case GET_SINGLE_POST_SUCCESS:
+        return {
+            ...state,
+            isLoading: false,
+            post: action.payload
+        };
+        case GET_SINGLE_POST_FAIL:
+        return {
+            ...state,
+            isLoading: false,
+            error: action.payload
+        };
+        // ---POST ACTIVITIES---
+        case ADD_POST_START:
+        return {
+            ...state,
+            isLoading: true,
+            error: "",
+            addedSuccessfully: false
+        }
+        case ADD_POST_SUCCESS:
+        return {
+            ...state,
+            isLoading: false,
+            addedSuccessfully: true
+        };
+        case ADD_POST_FAIL:
+        return {
+            ...state,
+            isLoading: false,
+            error: action.payload
+        };
+        default: return state;
+    }
+}
+
+export default postsReducer;


### PR DESCRIPTION
# Description

- Boilerplate postActions and postRouter
- Create PostModal and TrainingSeriesPosts components, remove Post component
- Refactor TrainingSeriesView to have two nested routes, TrainingSeriesSubView and TrainingSeriesPosts
- Dynamically render TrainingSeriesPosts with information of selected training series

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran app on localhost and tested routing on the front-end. Made sure other features still worked. Ensured that the routes are dynamically rendered based on 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
