### PR TITLE
Disable "Assign Team Members" button if no members on account

### DIFF
--- a/client/src/components/TrainingSeries/AddMembersToTrainingSeries/AddMember.js
+++ b/client/src/components/TrainingSeries/AddMembersToTrainingSeries/AddMember.js
@@ -155,8 +155,8 @@ const TeamMemberContainer = styled.div`
 const LoadingImage = styled.img`
   width: 40px;
   overflow: hidden;
-  pointerEvents: none,
-  cursor: not-allowed,
+  pointerEvents: none;
+  cursor: not-allowed;
 `;
 
 const disabled = {

--- a/client/src/components/TrainingSeries/TrainingSeriesPosts.js
+++ b/client/src/components/TrainingSeries/TrainingSeriesPosts.js
@@ -1,5 +1,6 @@
 // displays all posts of a training series
-import React, {useState, useEffect} from 'react';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
 // import Button from '@material-ui/core/Button';
 import Fab from '@material-ui/core/Fab';
@@ -175,6 +176,7 @@ class TrainingSeriesPosts extends React.Component {
 
   render() {
     const {classes} = this.props;
+
     let titleEdit;
     if (this.state.editingTitle) {
       titleEdit = (
@@ -207,6 +209,29 @@ class TrainingSeriesPosts extends React.Component {
         </>
       );
     }
+
+    let assignedMembersStatus;
+    if (this.props.teamMembers.length) {
+      assignedMembersStatus = (
+        <>
+            <Button onClick={this.routeToAssigning}>
+              Click to assign members
+            </Button>
+            {this.props.assignments.map(member => (
+              <TrainingSeriesAssignment member={member} />
+            ))}
+        </>
+      )
+    } else {
+      assignedMembersStatus = (
+        <>
+            <Button disabled>
+              Click to assign members
+            </Button>
+            <p>You don't have any team members to assign. <Link to="/home/create-team-member/">Click here</Link> to add a member to your account.</p>
+        </>
+      )
+    }
     return (
       <>
         {this.state.displaySnackbar && (
@@ -220,15 +245,7 @@ class TrainingSeriesPosts extends React.Component {
         <PageContainer>
           <Paper className={classes.paper}>{titleEdit}</Paper>
           <Paper className={classes.paper}>
-            <Button onClick={this.routeToAssigning}>
-              Click to assign members
-            </Button>
             <HeaderContainer>
-              {/* <PostModal
-        trainingSeries={this.props.singleTrainingSeries}
-        createAPost={this.props.createAPost}
-        editPost={this.props.editPost}
-      /> */}
               <Typography variant="title">Messages</Typography>
               <ButtonContainer>
                 <Fab
@@ -253,16 +270,9 @@ class TrainingSeriesPosts extends React.Component {
                     secondary={post.postDetails}
                   />
                   <ListItemSecondaryAction className={classes.secondaryAction}>
-                    {/* <IconButton aria-label="Delete"> */}
                     <div>
                       <p>{post.daysFromStart} days</p>
                     </div>
-                    {/* <PostOptionsModal
-                editPost={this.props.editPost}
-                deletePost={this.props.deletePost}
-                singleTrainingSeries={this.props.singleTrainingSeries}
-                post={post}
-              /> */}
                     <ListButtonContainer>
                       <i
                         className={`material-icons ${classes.icons}`}
@@ -277,7 +287,6 @@ class TrainingSeriesPosts extends React.Component {
                         id={post.postID}
                       />
                     </ListButtonContainer>
-                    {/* </IconButton> */}
                   </ListItemSecondaryAction>
                 </ListItem>
               ))}
@@ -285,9 +294,7 @@ class TrainingSeriesPosts extends React.Component {
           </Paper>
           <Paper className={classes.paper}>
             <Typography variant="title">Assigned Team Members</Typography>
-            {this.props.assignments.map(member => (
-              <TrainingSeriesAssignment member={member} />
-            ))}
+                {assignedMembersStatus}
           </Paper>
         </PageContainer>
       </>
@@ -336,6 +343,7 @@ const mapStateToProps = state => ({
   posts: state.postsReducer.posts,
   assignments: state.trainingSeriesReducer.assignments,
   trainingSeries: state.trainingSeriesReducer.trainingSeries,
+  teamMembers: state.teamMembersReducer.teamMembers,
 });
 
 TrainingSeriesPosts.propTypes = {};


### PR DESCRIPTION
# Description

- "Assign Team Members" button is disabled on Training Series page if 0 team members exist on a user's account.
- A link is provided on the same page to the create team member component
- "Assign Team Members" button is functional once 1 or more members exists

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A - tested on localhost - tested new functionality

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
